### PR TITLE
Key Vault Access via RBAC

### DIFF
--- a/mockSpacestation.bicep
+++ b/mockSpacestation.bicep
@@ -31,7 +31,7 @@ resource keyvault 'Microsoft.KeyVault/vaults@2021-04-01-preview' = {
   properties: {
     enabledForDeployment: true
     enabledForTemplateDeployment: true
-    enableRbacAuthorization: true
+    enableRbacAuthorization: false
     networkAcls: {
       defaultAction: 'Allow'
       bypass: 'AzureServices'

--- a/mockSpacestation.json
+++ b/mockSpacestation.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.451.19169",
-      "templateHash": "5330333637957033402"
+      "version": "0.4.613.9944",
+      "templateHash": "2571482893656664344"
     }
   },
   "parameters": {
@@ -85,8 +85,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.451.19169",
-              "templateHash": "12941320670909116395"
+              "version": "0.4.613.9944",
+              "templateHash": "4778199918038842802"
             }
           },
           "parameters": {
@@ -112,7 +112,7 @@
           },
           "functions": [],
           "variables": {
-            "sshKeyGenScript": "echo -e \\'y\\' | ssh-keygen -f scratch -N \"\" &&\nprivateKey=$(cat scratch) &&\npublicKey=$(cat scratch.pub) &&\njson=\"{\\\"keyinfo\\\":{\\\"privateKey\\\":\\\"$privateKey\\\",\\\"publicKey\\\":\\\"$publicKey\\\"}}\" &&\necho \"$json\" > \"$AZ_SCRIPTS_OUTPUT_PATH\"\n"
+            "sshKeyGenScript": "#!/bin/bash\n\necho -e \\'y\\' | ssh-keygen -f scratch -N \"\" &&\nprivateKey=$(cat scratch) &&\npublicKey=$(cat scratch.pub) &&\njson=\"{\\\"keyinfo\\\":{\\\"privateKey\\\":\\\"$privateKey\\\",\\\"publicKey\\\":\\\"$publicKey\\\"}}\" &&\necho \"$json\" > \"$AZ_SCRIPTS_OUTPUT_PATH\"\n"
           },
           "resources": [
             {
@@ -159,7 +159,7 @@
             },
             "privateKeySecretName": {
               "type": "string",
-              "value": "[format('{0}/{1}', parameters('keyvaultName'), parameters('privateKeySecretName'))]"
+              "value": "[parameters('privateKeySecretName')]"
             }
           }
         }
@@ -197,8 +197,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.451.19169",
-              "templateHash": "3766214066570027043"
+              "version": "0.4.613.9944",
+              "templateHash": "14656231286454718324"
             }
           },
           "parameters": {
@@ -485,8 +485,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.451.19169",
-              "templateHash": "3766214066570027043"
+              "version": "0.4.613.9944",
+              "templateHash": "14656231286454718324"
             }
           },
           "parameters": {

--- a/modules/sshKeyGen.sh
+++ b/modules/sshKeyGen.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo -e \'y\' | ssh-keygen -f scratch -N "" &&
+privateKey=$(cat scratch) &&
+publicKey=$(cat scratch.pub) &&
+json="{\"keyinfo\":{\"privateKey\":\"$privateKey\",\"publicKey\":\"$publicKey\"}}" &&
+echo "$json" > "$AZ_SCRIPTS_OUTPUT_PATH"


### PR DESCRIPTION
changes...

getSshCommands.sh
RBAC Policy assignments via getSshCommands.sh done. string sanitization needs to be looked at. the 2 variables for the policy had trailing charaxcters

sshKey.bicep:
Replaced the inline script with "var sshKeyGenScript = loadTextContent('./sshKeyGen.sh')"
It's cleaner and allows for proper tracking of the script itself as a seperate file.

changed the resource definition from

resource publicKeySecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
name: '${keyvault.name}/${publicKeySecretName}'
properties: {
value: sshKeyGenerationScript.properties.outputs.keyinfo.publicKey
}
}

to

resource publicKeySecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
parent: keyvault
name: publicKeySecretName
properties: {
value: sshKeyGenerationScript.properties.outputs.keyinfo.publicKey
}
}

eliminating the need for concatenation of strings in the name.

sshKeyGen.sh
New file for the embedded deployment script