### PR TITLE
add linguist override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Linguist overrides
+*.md linguist-detectable=true


### PR DESCRIPTION
Seeing if I can override the [linguist](https://docs.github.com/en/enterprise-server@2.21/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github) setting, here's main before:

![image](https://user-images.githubusercontent.com/4622125/130360404-237faae5-0d8c-435f-ae6f-3b112cd2de66.png)

(and docs to linguist https://github.com/github/linguist)